### PR TITLE
term_validator_restrict_embed_warningを追加。警告のファイル埋め込みを抑止できるように

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,9 @@ conf.py
    警告ログのレベルを指定します。レベルは ``info``, ``warn``, ``error`` から指定します。
    デフォルトは ``warn`` です。
 
+:term_validator_restrict_embed_warning:
+   ファイル埋め込みの警告を抑止します。デフォルトはFalseです。
+
 VS Code
 ===========
 

--- a/sphinx_term_validator.py
+++ b/sphinx_term_validator.py
@@ -348,7 +348,7 @@ def doctree_resolved(app, doctree, docname):
                     docpath = app.env.doc2path(docname)
                     location = f"{docpath}:{msg.location}"
                     logger_method(u'sphinx_term_validator: %s', msg, location=location)
-            if app.config.term_validator_restrict_embed_warning:
+            if not app.config.term_validator_restrict_embed_warning:
                 # ページ埋め込みなら、nodeに追加する
                 for msg in msgs:
                     sm = system_message(msg, docname, msg.lineno)

--- a/sphinx_term_validator.py
+++ b/sphinx_term_validator.py
@@ -348,7 +348,8 @@ def doctree_resolved(app, doctree, docname):
                     docpath = app.env.doc2path(docname)
                     location = f"{docpath}:{msg.location}"
                     logger_method(u'sphinx_term_validator: %s', msg, location=location)
-            if 1:  # ページ埋め込みなら、nodeに追加する
+            if app.config.term_validator_restrict_embed_warning:
+                # ページ埋め込みなら、nodeに追加する
                 for msg in msgs:
                     sm = system_message(msg, docname, msg.lineno)
                     node.parent += sm
@@ -394,5 +395,9 @@ def setup(app):
     # :term_validator_loglevel:
     #       log level: info, warn, error
     app.add_config_value('term_validator_loglevel', 'warning', 'env')
+
+    # :term_validator_restrict_embed_warning:
+    #       ファイル埋め込みの警告を抑止します。
+    app.add_config_value('term_validator_restrict_embed_warning', False, 'env')
 
     app.connect('doctree-resolved', doctree_resolved)


### PR DESCRIPTION
出力されるファイルへの警告埋め込みを抑止できるように設定を追加しました。